### PR TITLE
On successful payment, set status of non-shippable orders to "delivered"

### DIFF
--- a/src/CommunityStore/Payment/Methods/CommunityStoreStripeCheckout/CommunityStoreStripeCheckoutPaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/CommunityStoreStripeCheckout/CommunityStoreStripeCheckoutPaymentMethod.php
@@ -261,7 +261,11 @@ class CommunityStoreStripeCheckoutPaymentMethod extends StorePaymentMethod
 
                 if ($order) {
                     $order->completeOrder($session->payment_intent);
-                    $order->updateStatus(StoreOrderStatus::getStartingStatus()->getHandle());
+                    if ($order->isShippable()) {
+                        $order->updateStatus(StoreOrderStatus::getStartingStatus()->getHandle());
+                    } else {
+                        $order->updateStatus('delivered');
+                    }
                     $success = true;
                 }
             }


### PR DESCRIPTION
When an order is placed which only contains non-shippable items, the status should go straight to "delivered", as no further processing is needed from the store administrator.